### PR TITLE
Missing header for find function

### DIFF
--- a/src/tools/ClientMain.cc
+++ b/src/tools/ClientMain.cc
@@ -8,6 +8,7 @@
  * nor does it submit to any jurisdiction.
  */
 
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
 #include <optional>


### PR DESCRIPTION
The GNU v14 compiler fails to build ecflow-light due to a missing header file (v13 and earlier don't seem to mind):

`.../ecflow-light/src/tools/ClientMain.cc: In static member function 'static std::optional<std::pair<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > ClientTool::get_option(const eckit::option::CmdArgs&, const std::string&)':`
`.../ecflow-light/src/tools/ClientMain.cc:156:35: error: no matching function for call to 'find(std::__cxx11::basic_string<char>::iterator, std::__cxx11::basic_string<char>::iterator, char)'
  156 |             auto found = std::find(option_value.begin(), option_value.end(), ':');`

Found on Mac OS as part of an IFS build.