### PR TITLE
Create C comaptible arrays before calling function

### DIFF
--- a/src/libecflow_lightf/ecflow_light.F90
+++ b/src/libecflow_lightf/ecflow_light.F90
@@ -58,8 +58,10 @@ contains
         character(*), intent(in) :: name
         integer, intent(in), value :: value
         integer :: error
+        character(len=:), allocatable :: namec
 
-        error = ecflow_light_update_meter_f_api(str_fortran_to_c(name), value)
+        namec = str_fortran_to_c(name)
+        error = ecflow_light_update_meter_f_api(namec, value)
 
     end function
 
@@ -69,8 +71,12 @@ contains
         character(*), intent(in) :: name
         character(*), intent(in) :: value
         integer :: error
-
-        error = ecflow_light_update_label_f_api(str_fortran_to_c(name), str_fortran_to_c(value))
+        character(len=:), allocatable :: namec
+        character(len=:), allocatable :: valuec
+        
+        namec = str_fortran_to_c(name)
+        valuec = str_fortran_to_c(value)
+        error = ecflow_light_update_label_f_api(namec, valuec)
 
     end function
 
@@ -80,8 +86,10 @@ contains
         character(*), intent(in) :: name
         integer, intent(in), value :: value
         integer :: error
-
-        error = ecflow_light_update_event_f_api(str_fortran_to_c(name), value)
+        character(len=:), allocatable :: namec
+        
+        namec = str_fortran_to_c(name)
+        error = ecflow_light_update_event_f_api(namec, value)
 
     end function
 


### PR DESCRIPTION
Otherwise newer ifort compilers will give error: 
#8284: If the actual argument is scalar, the dummy argument shall be scalar unless the actual argument is of type character or is an element of an array that is not assumed shape, pointer, or polymorphic.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 