### PR TITLE
Avoid static initialisation of C++ objects

### DIFF
--- a/src/libecflow_light/ecflow/light/TinyREST.cc
+++ b/src/libecflow_light/ecflow/light/TinyREST.cc
@@ -31,16 +31,20 @@ std::ostream& operator<<(std::ostream& s, const Body& o) {
     return s;
 }
 
-std::vector<Status> Status::status_set_ = {
+const std::array<Status, 6> Status::status_set_ = {
+    // clang-format off
     // Informal responses
     Status{Code::UNKNOWN, "UNKNOWN"},
     // Successful responses
     Status{Code::OK, "OK"},
     // Client Error responses
-    Status{Code::BAD_REQUEST, "BAD_REQUEST"}, Status{Code::UNAUTHORIZED, "UNAUTHORIZED"},
+    Status{Code::BAD_REQUEST, "BAD_REQUEST"},
+    Status{Code::UNAUTHORIZED, "UNAUTHORIZED"},
     Status{Code::NOT_FOUND, "NOT_FOUND"},
     // Server Error responses
-    Status{Code::INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR"}};
+    Status{Code::INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR"}
+    // clang-format on
+};
 
 namespace detail {
 

--- a/src/libecflow_light/ecflow/light/TinyREST.h
+++ b/src/libecflow_light/ecflow/light/TinyREST.h
@@ -12,9 +12,10 @@
 #define ECFLOW_LIGHT_TINYREST_H
 
 #include <algorithm>
+#include <array>
 #include <iostream>
-#include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "ecflow/light/StringUtils.h"
@@ -96,7 +97,7 @@ public:
         INTERNAL_SERVER_ERROR = 500
     };
 
-    static const std::string& as_description(Code code) {
+    static std::string_view as_description(Code code) {
         auto found = std::find_if(std::begin(status_set_), std::end(status_set_),
                                   [&code](const Status& status) { return status.code_ == code; });
         if (found == std::end(status_set_)) {
@@ -121,9 +122,9 @@ private:
     Status(Code code, std::string_view description) : code_{code}, description_{description} {}
 
     Code code_;
-    std::string description_;
+    std::string_view description_;
 
-    static std::vector<Status> status_set_;
+    static const std::array<Status, 6> status_set_;
 };
 
 struct Field {


### PR DESCRIPTION

### Description

In order to support the use in C environment, and ensure the finalisation is successful (i.e. all objects are conveniently destroyed) these changes avoid dynamic allocation by using std::array instead of std::vector, and std::string_view instead of std::string.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 