### PR TITLE
Add missing header required by gnu 15

### DIFF
--- a/src/libecflow_light/ecflow/light/TinyREST.h
+++ b/src/libecflow_light/ecflow/light/TinyREST.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+#include <cstdint>
 
 #include "ecflow/light/StringUtils.h"
 


### PR DESCRIPTION
### Description

This fixes a compilation failure when using gnu 15.2.0 which fails due to the missing include file. Once this is merged could you create a new tag with this fix as we would like to start testing IFS with gnu 15, thanks!

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
